### PR TITLE
Ctrl + Enter の操作を Mac の挙動と揃える

### DIFF
--- a/win2mac-like-keybinding.ahk
+++ b/win2mac-like-keybinding.ahk
@@ -297,9 +297,9 @@ use_emacs_like_keybind() {
 !z::Send, ^z
 !+z::Send, ^+z
 !/::Send, ^/
-!+/::Send, !^/
+!+/::Send, ^+/
 !,::Send, ^,
-!+,::Send, !^,
+!+,::Send, ^+,
 !Enter::Send, ^{Enter}
 
 ; Win -> Alt

--- a/win2mac-like-keybinding.ahk
+++ b/win2mac-like-keybinding.ahk
@@ -300,6 +300,7 @@ use_emacs_like_keybind() {
 !+/::Send, !^/
 !,::Send, ^,
 !+,::Send, !^,
+!Enter::Send, ^{Enter}
 
 ; Win -> Alt
 ; まずはアルファベットのみ


### PR DESCRIPTION
Fixes #6 